### PR TITLE
Set fusion data output mode to Android

### DIFF
--- a/src/IMU.cpp
+++ b/src/IMU.cpp
@@ -80,8 +80,8 @@ int IMUClass::begin()
   // enable external clock
   writeRegister(BNNO055_SYS_TRIGGER_REG, 0x80);
 
-  // set acceleration unit to mG's
-  writeRegister(BNNO055_UNIT_SEL_REG, 0x01);
+  // set acceleration unit to mG's, and fusion data output mode to Android
+  writeRegister(BNNO055_UNIT_SEL_REG, 0x81);
 
   // set X = X, Y = Y, Z = Z
   writeRegister(BNNO055_AXIS_MAP_CONFIG_REG, 0x24);


### PR DESCRIPTION
As discussed with Dominic and Bosch by email:

> In the video, you can observe that the heading jumps when the roll hits +- 45 degrees. This is due to the interpretation of the Eulers in the configured output system (Totally normal behavior). There are 2 types of Eulers defined for the BNO055, Windows and Android. Since the jump is at 45 degrees, I assume you are in the Windows orientation system. The recommended way to use the sensor for Desktop applications is to use it Android mode. Alternatively there are libraries on Github that convert quaternions to Eulers. If you need further help let me know.

Datasheet section:

<img width="982" alt="screen shot 2019-01-16 at 9 36 17 am" src="https://user-images.githubusercontent.com/1163840/51255919-32c13600-1972-11e9-9b70-31749e319730.png">

cc/ @8bitkick