### PR TITLE
Support for reading quaternions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,4 +7,4 @@ image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/compile-examples.yml/badge.svg["Compile Examples status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/compile-examples.yml"]
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
-Allows you to read the acceleration, gyroscope, magnetic fields and Euler angles from the IMU on your MKR IMU Shield.
+Allows you to read the acceleration, gyroscope, magnetic fields, Euler angles and quaternions from the IMU on your MKR IMU Shield.

--- a/src/IMU.h
+++ b/src/IMU.h
@@ -58,7 +58,7 @@ public:
   virtual int quaternionAvailable(); // Number of samples in the FIFO.
   virtual float quaternionSampleRate(); // Sampling rate of the sensor.
 
-  virtual float readTemperature(); // Result are in degrees Celcius
+  virtual float readTemperature(); // Result are in degrees Celsius
 
 private:
   int readRegister(uint8_t address);

--- a/src/IMU.h
+++ b/src/IMU.h
@@ -34,7 +34,7 @@ public:
   void end();
 
   // Accelerometer
-  virtual int readAcceleration(float& x, float& y, float& z); // Results are in g (earth gravity).
+  virtual int readAcceleration(float& x, float& y, float& z); // Results are in G (earth gravity).
   virtual int accelerationAvailable(); // Number of samples in the FIFO.
   virtual float accelerationSampleRate(); // Sampling rate of the sensor.
   
@@ -53,12 +53,17 @@ public:
   int eulerAnglesAvailable(); // Number of samples in the FIFO.
   float eulerAnglesSampleRate(); // Sampling rate of the sensor.
 
-  virtual float readTemperature(); // Result are in degrees Celsius
+  // Quaternion
+  int readQuaternion(float& sw, float& sx, float& sy, float& sz); 
+  virtual int quaternionAvailable(); // Number of samples in the FIFO.
+  virtual float quaternionSampleRate(); // Sampling rate of the sensor.
+
+  virtual float readTemperature(); // Result are in degrees Celcius
 
 private:
   int readRegister(uint8_t address);
-  int readRegisters(uint8_t address, uint8_t* data, size_t length);
   int writeRegister(uint8_t address, uint8_t value);
+  int readRegisters(uint8_t address, uint8_t* data, size_t length);
 
 private:
   TwoWire* _wire;
@@ -68,6 +73,8 @@ private:
   unsigned long _lastGyroscopeReadMillis;
   unsigned long _lastMagneticFieldReadMillis;
   unsigned long _lastEulerAnglesReadMillis;
+  unsigned long _lastQuaternionReadMillis;
+  
 };
 
 extern IMUClass IMU;


### PR DESCRIPTION
This branch added methods to the lib in the familiar style to read quaternions representing absolute orientation from the BNO055. Generally speaking, quaternions are a better choice for representing absolute orientation than Euler angles, since they don't suffer from gimbal lock. Code is inspired (much!) by Adafruit BNO055 lib.